### PR TITLE
removes example game reference

### DIFF
--- a/climbARUnity/Assets/Shared/Scripts/SceneUtils.cs
+++ b/climbARUnity/Assets/Shared/Scripts/SceneUtils.cs
@@ -20,7 +20,6 @@ static class SceneUtils
     // name of the scene which we would display on the menu
     public static Dictionary<string, string> SceneNameToDisplayName = new Dictionary<string, string>()
     {
-        { SceneNames.exampleGame, "    Example\n    Game" },
         { SceneNames.musicGame, "    Music\n    Game" },
         { SceneNames.menu, "    Menu" },
         { SceneNames.rocManGamePlay, "    RocMan\n    Game" },


### PR DESCRIPTION
The code for the example game is still in the project - no need to
delete that.