### PR TITLE
A meta data file (.meta) exists but its asset 'Assets/Resources/Sound…

### DIFF
--- a/climbARUnity/Assets/Resources/Sounds.meta
+++ b/climbARUnity/Assets/Resources/Sounds.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: d708e810ee2305c4bacd651c8b1516b5
-folderAsset: yes
-timeCreated: 1488772812
-licenseType: Free
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
…s' can't be found. When moving or deleting files outside of Unity, please ensure that the corresponding .meta file is moved or deleted along with it.